### PR TITLE
Handle high-rep sets without blocking

### DIFF
--- a/script.js
+++ b/script.js
@@ -414,6 +414,7 @@ function finishWorkout() {
     // Recopilar datos del entrenamiento
     const exerciseCards = document.querySelectorAll('.exercise-card');
     let invalidReps = false;
+    let highReps = false;
     exerciseCards.forEach(card => {
         if (invalidReps) return;
         const exerciseName = card.querySelector('.exercise-name').textContent;
@@ -426,9 +427,14 @@ function finishWorkout() {
             if (reps) { // Solo verificamos que haya repeticiones
                 const parsedWeight = weight ? parseFloat(weight) : 0; // Si no hay peso, considerar 0
                 const parsedReps = parseInt(reps);
-                if (parsedWeight > 0 && (parsedReps < 1 || parsedReps > 10)) {
-                    invalidReps = true;
-                    return;
+                if (parsedWeight > 0) {
+                    if (parsedReps < 1) {
+                        invalidReps = true;
+                        return;
+                    }
+                    if (parsedReps > 10) {
+                        highReps = true;
+                    }
                 }
                 sets.push({
                     weight: parsedWeight,
@@ -443,7 +449,7 @@ function finishWorkout() {
             // Calcular 1RM estimado para ejercicios con peso
             let estimated1RM = 0;
             sets.forEach(set => {
-                if (set.weight > 0 && set.reps >= 1 && set.reps <= 10) {
+                if (set.weight > 0 && set.reps >= 1) {
                     const oneRM = calculate1RM(set.weight, set.reps);
                     if (oneRM && oneRM > estimated1RM) {
                         estimated1RM = oneRM;
@@ -460,7 +466,7 @@ function finishWorkout() {
     });
 
     if (invalidReps) {
-        alert('Para calcular el 1RM, introduce entre 1 y 10 repeticiones para series con peso.');
+        alert('Para calcular el 1RM, introduce al menos 1 repetición para series con peso.');
         return;
     }
 
@@ -477,7 +483,11 @@ function finishWorkout() {
     document.getElementById('workoutActive').style.display = 'none';
     document.getElementById('exercisesList').innerHTML = '';
 
-    alert('¡Entrenamiento guardado exitosamente!');
+    let finalMessage = '¡Entrenamiento guardado exitosamente!';
+    if (highReps) {
+        finalMessage += '\n\nLa fórmula para calcular el equivalente a una repetición máxima funciona mejor cuando se hacen entre 1 y 10 repeticiones al fallo. Si se hacen más, se tomará 10 como valor en la fórmula.';
+    }
+    alert(finalMessage);
 }
 
 // Iniciar descanso
@@ -852,6 +862,7 @@ function saveExerciseEdit(workoutIndex, exerciseIndex) {
     const exercise = workout.exercises[exerciseIndex];
     const container = document.getElementById('editSetsContainer');
     const sets = [];
+    let highReps = false;
     
     // Recopilar datos de las series
     for (let i = 0; i < container.children.length; i++) {
@@ -862,9 +873,14 @@ function saveExerciseEdit(workoutIndex, exerciseIndex) {
             const weight = parseFloat(weightInput.value) || 0;
             const reps = parseInt(repsInput.value) || 0;
 
-            if (weight > 0 && (reps < 1 || reps > 10)) {
-                alert('Para calcular el 1RM, introduce entre 1 y 10 repeticiones para series con peso.');
-                return;
+            if (weight > 0) {
+                if (reps < 1) {
+                    alert('Para calcular el 1RM, introduce al menos 1 repetición para series con peso.');
+                    return;
+                }
+                if (reps > 10) {
+                    highReps = true;
+                }
             }
 
             if (weight > 0 && reps > 0) {
@@ -884,7 +900,7 @@ function saveExerciseEdit(workoutIndex, exerciseIndex) {
     // Recalcular 1RM
     let estimated1RM = 0;
     sets.forEach(set => {
-        if (set.weight > 0 && set.reps >= 1 && set.reps <= 10) {
+        if (set.weight > 0 && set.reps >= 1) {
             const oneRM = calculate1RM(set.weight, set.reps);
             if (oneRM && oneRM > estimated1RM) {
                 estimated1RM = oneRM;
@@ -898,7 +914,11 @@ function saveExerciseEdit(workoutIndex, exerciseIndex) {
     closeEditModal();
     displayWorkoutHistory();
     updateStats();
-    alert('Ejercicio actualizado correctamente.');
+    let finalMessage = 'Ejercicio actualizado correctamente.';
+    if (highReps) {
+        finalMessage += '\n\nLa fórmula para calcular el equivalente a una repetición máxima funciona mejor cuando se hacen entre 1 y 10 repeticiones al fallo. Si se hacen más, se tomará 10 como valor en la fórmula.';
+    }
+    alert(finalMessage);
 }
 
 // Guardar edición de descanso
@@ -1061,10 +1081,11 @@ function updateStats() {
 
 // Calcular 1RM usando fórmula de Brzycki
 function calculate1RM(weight, reps) {
-    if (reps >= 1 && reps <= 10) {
-        return weight * (36 / (37 - reps));
+    if (reps < 1) {
+        return null;
     }
-    return null;
+    const effectiveReps = Math.min(reps, 10);
+    return weight * (36 / (37 - effectiveReps));
 }
 
 // Detectar si un ejercicio es de peso corporal


### PR DESCRIPTION
## Summary
- Allow finishing workouts that include sets with more than 10 reps, clamping reps only for 1RM calculation and warning once with detailed message
- Apply same high-rep handling to edited exercises and remove redundant 1RM clamping outside the calculator

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1a2a188f08327acfe6b99a1988c17