### PR TITLE
Fix set deletion button in workout sessions

### DIFF
--- a/script.js
+++ b/script.js
@@ -753,7 +753,7 @@ function editRegularExercise(workoutIndex, exerciseIndex) {
                 <div style="display: flex; gap: 10px;">
                     <input type="number" id="editWeight${setIndex}" value="${set.weight}" placeholder="Peso (kg)" style="flex: 1;">
                     <input type="number" id="editReps${setIndex}" value="${set.reps}" placeholder="Reps" style="flex: 1;">
-                    <button class="btn btn-sm btn-danger" onclick="removeSet(${workoutIndex}, ${exerciseIndex}, ${setIndex})">
+                    <button class="btn btn-sm btn-danger" onclick="removeSetEdit(${workoutIndex}, ${exerciseIndex}, ${setIndex})">
                         <i class="fas fa-trash"></i>
                     </button>
                 </div>
@@ -828,7 +828,7 @@ function addNewSet(workoutIndex, exerciseIndex) {
             <div style="display: flex; gap: 10px;">
                 <input type="number" id="editWeight${setIndex}" placeholder="Peso (kg)" style="flex: 1;">
                 <input type="number" id="editReps${setIndex}" placeholder="Reps" style="flex: 1;">
-                <button class="btn btn-sm btn-danger" onclick="removeSet(${workoutIndex}, ${exerciseIndex}, ${setIndex})">
+                <button class="btn btn-sm btn-danger" onclick="removeSetEdit(${workoutIndex}, ${exerciseIndex}, ${setIndex})">
                     <i class="fas fa-trash"></i>
                 </button>
             </div>
@@ -838,8 +838,8 @@ function addNewSet(workoutIndex, exerciseIndex) {
     container.insertAdjacentHTML('beforeend', newSetHTML);
 }
 
-// Eliminar serie
-function removeSet(workoutIndex, exerciseIndex, setIndex) {
+// Eliminar serie en el modal de edición
+function removeSetEdit(workoutIndex, exerciseIndex, setIndex) {
     const container = document.getElementById('editSetsContainer');
     const sets = container.children;
     


### PR DESCRIPTION
## Summary
- Rename edit-modal `removeSet` function to `removeSetEdit` to avoid clobbering workout set removal logic
- Update edit modal buttons to call `removeSetEdit`

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e09394b88327b88dc3f0dbf5d439