### PR TITLE
Configure Vite base path for GitHub Pages

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_BASE_URL=./

--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="%VITE_BASE_URL%src/main.jsx"></script>
   </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: './',
+  base: '/gymtracker/',
 })


### PR DESCRIPTION
## Summary
- configure Vite with `/gymtracker/` base for GitHub Pages
- load client script via `%VITE_BASE_URL%src/main.jsx`
- add environment variable `VITE_BASE_URL` for builds

## Testing
- `npm run lint`
- `npm run build`
- `npm run deploy` *(fails: Failed to get remote.origin.url)*

------
https://chatgpt.com/codex/tasks/task_e_68b417bb4f94832792526c5db23c8d0d