### PR TITLE
Remove base URL env and fix index entry script

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VITE_BASE_URL=./
+# No custom base URL; Vite config handles deployment path

--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="%VITE_BASE_URL%src/main.jsx"></script>
+    <script type="module" src="src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove VITE_BASE_URL setting from `.env`
- point `index.html` script to direct `src/main.jsx`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b41af586108327bd153fc5b7eb55d1