### PR TITLE
fix: render fallback tab when current id is invalid

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,9 @@ const tabs = [
 
 export default function App() {
   const [current, setCurrent] = useState('profile');
-  const CurrentComponent = tabs.find(t => t.id === current).component;
+  // Ensure we always have a component to render even if the tab id is invalid
+  const CurrentComponent =
+    tabs.find(t => t.id === current)?.component || Profile;
 
   return (
     <div className="min-h-screen bg-gray-100">


### PR DESCRIPTION
## Summary
- prevent blank screen by rendering Profile tab when current tab id is invalid

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b41cdcef3c83279e2b2cec0ab5bcf3